### PR TITLE
Makes SDU use the job queue [MBSD-256]

### DIFF
--- a/_settings/LocalSettings.php
+++ b/_settings/LocalSettings.php
@@ -372,8 +372,8 @@ if ( !isset( $wgScribuntoEngineConf ) ) {
 // WLDR-312
 $wgScribuntoEngineConf['luasandbox']['cpuLimit'] = 20;
 
-// MBSD-256
 wfLoadExtension( 'SemanticDependencyUpdater' );
+// MBSD-256
 $wgSDUUseJobQueue = true;
 
 // MBSD-192

--- a/_settings/LocalSettings.php
+++ b/_settings/LocalSettings.php
@@ -372,7 +372,9 @@ if ( !isset( $wgScribuntoEngineConf ) ) {
 // WLDR-312
 $wgScribuntoEngineConf['luasandbox']['cpuLimit'] = 20;
 
+// MBSD-256
 wfLoadExtension( 'SemanticDependencyUpdater' );
+$wgSDUUseJobQueue = true;
 
 // MBSD-192
 wfLoadExtension( 'Gadgets' );


### PR DESCRIPTION
We try this as a workaround against CSE4 ("This page has no properties" issue).