### PR TITLE
Require production profile to enable matomo

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -112,6 +112,8 @@ services:
         restart: unless-stopped
         depends_on:
             - db
+        profiles:
+            - production
         environment:
             - MATOMO_DATABASE_HOST=db
             - MATOMO_DATABASE_DBNAME=matomo


### PR DESCRIPTION
We don't need usage statistics in testing environments.

MBSD-253