### PR TITLE
Adjusted traefik to route to matomo

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -111,7 +111,6 @@ services:
         image: matomo
         restart: unless-stopped
         networks:
-            - default
             - traefik-public
         depends_on:
             - db
@@ -124,11 +123,12 @@ services:
             - ./_data/matomo:/var/www/html
         labels:
             - "traefik.enable=true"
-            - "traefik.http.routers.matomo.rule=Host(`bugsigdb-staging.wikiworks.com`) && PathPrefix(`/matomo`)"
-            - "traefik.http.routers.matomo.entrypoints=websecure"
-            - "traefik.http.middlewares.matomo-stripprefix.stripprefix.prefixes=/matomo"
-            - "traefik.http.routers.${TRAEFIK_STACK_PREFIX}-matomo.middlewares=${TRAEFIK_STACK_PREFIX}-matomo-stripprefix"
-            - "traefik.http.routers.matomo.tls.certresolver=le"
+            - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-matomo.rule=Host(`bugsigdb.org`) && PathPrefix(`/matomo`)"
+            - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-matomo.entrypoints=websecure"
+            - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-matomo.tls.certresolver=le"
+            - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-matomo-stripprefix.stripprefix.prefixes=/matomo"
+            - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-matomo-stripprefix.stripprefix.forceSlash=true"
+            - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-matomo.middlewares=${COMPOSE_PROJECT_NAME}-matomo-stripprefix"
             - "traefik.http.services.matomo.loadbalancer.server.port=80"
 
     varnish:
@@ -202,7 +202,5 @@ services:
             - ./_logs/restic:/var/log
 
 networks:
-    default:
-        driver: bridge
     traefik-public:
         external: true

--- a/compose.yml
+++ b/compose.yml
@@ -111,6 +111,7 @@ services:
         image: matomo
         restart: unless-stopped
         networks:
+            - default
             - traefik-public
         depends_on:
             - db
@@ -129,7 +130,6 @@ services:
             - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-matomo-stripprefix.stripprefix.prefixes=/matomo"
             - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-matomo-stripprefix.stripprefix.forceSlash=true"
             - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-matomo.middlewares=${COMPOSE_PROJECT_NAME}-matomo-stripprefix"
-            - "traefik.http.services.matomo.loadbalancer.server.port=80"
 
     varnish:
         image: pastakhov/varnish:7.0

--- a/compose.yml
+++ b/compose.yml
@@ -124,7 +124,7 @@ services:
             - ./_data/matomo:/var/www/html
         labels:
             - "traefik.enable=true"
-            - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-matomo.rule=Host(`bugsigdb.org`) && PathPrefix(`/matomo`)"
+            - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-matomo.rule=Host(${MW_SITE_FQDN?Variable not set}) && PathPrefix(`/matomo`)"
             - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-matomo.entrypoints=websecure"
             - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-matomo.tls.certresolver=le"
             - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-matomo-stripprefix.stripprefix.prefixes=/matomo"

--- a/compose.yml
+++ b/compose.yml
@@ -110,6 +110,9 @@ services:
     matomo:
         image: matomo
         restart: unless-stopped
+        networks:
+            - default
+            - traefik-public
         depends_on:
             - db
         environment:
@@ -119,6 +122,14 @@ services:
             - MATOMO_DATABASE_PASSWORD=$MW_DB_INSTALLDB_PASS
         volumes:
             - ./_data/matomo:/var/www/html
+        labels:
+            - "traefik.enable=true"
+            - "traefik.http.routers.matomo.rule=Host(`bugsigdb-staging.wikiworks.com`) && PathPrefix(`/matomo`)"
+            - "traefik.http.routers.matomo.entrypoints=websecure"
+            - "traefik.http.middlewares.matomo-stripprefix.stripprefix.prefixes=/matomo"
+            - "traefik.http.routers.${TRAEFIK_STACK_PREFIX}-matomo.middlewares=${TRAEFIK_STACK_PREFIX}-matomo-stripprefix"
+            - "traefik.http.routers.matomo.tls.certresolver=le"
+            - "traefik.http.services.matomo.loadbalancer.server.port=80"
 
     varnish:
         image: pastakhov/varnish:7.0
@@ -191,5 +202,7 @@ services:
             - ./_logs/restic:/var/log
 
 networks:
+    default:
+        driver: bridge
     traefik-public:
         external: true


### PR DESCRIPTION
I have updated only the compose file but at this point it won't work because the location of matomo is at /var/www/html and in order to work need to be moved to /var/www/html/matomo. Alternatively, we need to edit the apache config file to add Alias to point to the /var/www/html.

MBSD-296