### PR TITLE
Update the Taqasta image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,7 @@ services:
             - ./_data/mysql:/var/lib/mysql
 
     web:
-        image: ghcr.io/wikiteq/taqasta:1.39.8-20240712-203
+        image: ghcr.io/wikiteq/taqasta:1.39.10-20241006-223 # 1.39.10
         env_file:
             - ./.env
             - ./.env.secret


### PR DESCRIPTION
Updated the taqasta image from taqasta:1.39.8-20240712-203 to taqasta:1.39.8-20240925-aa6085a, tested locally. 
After pulling the new image it was required to run php maintenance/update.php and everything was running.
If approved I can proceed to staging test.

MBSD-307